### PR TITLE
Add new `mouse` option to keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Using vim-plug:
 ```
 Plug 'VebbNix/lf-vim'
 ```
-If installing without a plugin manager, simply move all of the directories in this repository to your `~/.vim/` directory.
+If installing without a plugin manager, simply move all of the directories in this repository to your `~/.vim/` directory(or to`${XDG_DATA_HOME:-~/.local/share}/nvim/plugged` for Neovim users).
 
 # Info
 + Separate colours used for lf variables like `$f`, `$fx`, `$fs` and `$id`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Plug 'VebbNix/lf-vim'
 If installing without a plugin manager, simply move all of the directories in this repository to your `~/.vim/` directory.
 
 # Info
-+ Seperate colour used for lf variables like $f, $fx, $fs and $id.
++ Separate colours used for lf variables like `$f`, `$fx`, `$fs` and `$id`.
 + Shell script highlighting is used between `cmd [CMD] ${{ }}`.
 See screenshots for details.
 

--- a/syntax/lf.vim
+++ b/syntax/lf.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:  lf config file
 " Maintainer: Cameron Wright https://github.com/VebbNix
-" Last Change: 26 July 2020
+" Last Change: 31 Jan 2021
 
 if exists("b:current_syntax")
 	finish
@@ -27,7 +27,7 @@ syn keyword  lfKeyword        set cmd map cmap skipwhite
 "}}}
 
 "{{{ Options Keywords
-syn keyword  lfOptions        push up half-up up half-up page-up down half-down page-down updir open quit top bottom toggle invert unselect copy cut paste clear redraw reload read find find-back find-next find-prev search search-back search-next search-prev mark-save mark-load anchorfind color256 dircounts dirfirst drawbox globsearch icons hidden ignorecase ignoredia incsearch preview reverse smartcase smartdia wrapscan wrapscroll number relativenumber findlen period scrolloff tabstop errorfmt filesep ifs previewer promptfmt shell sortby timefmt ratios info shellopts hiddenfiles truncatechar
+syn keyword  lfOptions        push up half-up up half-up page-up down half-down page-down updir open quit top bottom toggle invert unselect copy cut paste clear redraw reload read find find-back find-next find-prev search search-back search-next search-prev mark-save mark-load anchorfind color256 dircounts dirfirst drawbox globsearch icons hidden ignorecase ignoredia incsearch preview reverse smartcase smartdia wrapscan wrapscroll number relativenumber findlen period scrolloff tabstop errorfmt filesep ifs previewer promptfmt shell sortby timefmt ratios info shellopts hiddenfiles truncatechar mouse
 "}}}
 
 "{{{ Special Matching


### PR DESCRIPTION
This was added in the latest `r20` release of `lf`, see https://github.com/gokcehan/lf/commit/13d19d84f9de0c0746fa2b68bdf4909744a045da.

Minor edits to README (typo+plugin location for Neovim).