### PR TITLE
Improve handling of escape sequences

### DIFF
--- a/syntax/lf.vim
+++ b/syntax/lf.vim
@@ -207,7 +207,8 @@ syn keyword  lfOptions
 "}}}
 
 "{{{ Special Matching
-syn match    lfSpecial        '<.*>\|\\.'
+syn match    lfSpecial        '\v\<.+\>'
+syn match    lfSpecial        '\v\\(["\\abfnrtv]|\o+)'
 "}}}
 
 "{{{ Shell Script Matching for cmd


### PR DESCRIPTION
Fixes #16 

Changes:

- `<>` is no longer matched, there must be something between the angled brackets
- The list of characters following `\` is more restrictive, only  `\"`, `\\`, `\a`, `\b`, `\f`, `\n`, `\r`, `\t` and `\v` are allowed
- Octal escape sequences (e.g. `\033`) are now supported

For reference, the escape handling in the `lf` parser is implemented here: https://github.com/gokcehan/lf/blob/6718a363349c5958acc743c261a6f241c33c3401/scan.go#L220-L256