### PR TITLE
Set `iskeyword` after loading shell syntax

### DIFF
--- a/syntax/lf.vim
+++ b/syntax/lf.vim
@@ -215,6 +215,7 @@ let s:shell_syntax = get(b:, 'lf_shell_syntax', s:shell_syntax)
 
 unlet b:current_syntax
 exe 'syn include @Shell '.s:shell_syntax
+syn iskeyword @,-
 let b:current_syntax = "lf"
 
 syn region lfCommand matchgroup=lfCommandMarker start=' \zs:\ze' end='$' keepend transparent


### PR DESCRIPTION
- Fixes #14 

I finally got around to investigating why `:open` isn't 'highlighted properly, it's because the shell syntax that is loaded to handle shell regions [allows `:` to be part of keywords](https://github.com/vim/vim/blob/ea67ba718d8af10cb7aa3b91379203f5dd7e50d7/runtime/syntax/sh.vim#L114), so it tries to resolve `:open` atomically as a keyword when it should just be `open`.

The only way I could think of to handle this is to just explicitly set `syn iskeyword` after loading the shell syntax. I think it's a good idea in general to specify this anyway otherwise it falls back to the user's `iskeyword` setting.