### PR TITLE
Fix outdated syntax version

### DIFF
--- a/syntax/lf.vim
+++ b/syntax/lf.vim
@@ -3,10 +3,10 @@
 " Maintainer: Andis Sprinkis <andis@sprinkis.com>
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 7 Sep 2025
+" Last Change: 26 Oct 2025
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
-" lf version: 38
+" lf version: 39
 
 if exists("b:current_syntax") | finish | endif
 


### PR DESCRIPTION
- Follow-up to [Update for upcoming r39 release](https://github.com/andis-sprinkis/lf-vim/commit/3d88b78eeb917c95f2d9a796f8c64c7ca388e7bb)

This PR updates the outdated version number.